### PR TITLE
MAINT: integrate.cumulative_simpson: simplify input validation and (nonstandard) broadcasting

### DIFF
--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -1046,7 +1046,7 @@ def cumulative_simpson(y, *, x=None, dx=1.0, axis=-1, initial=None):
     >>> plt.show()
 
     The output of `cumulative_simpson` is similar to that of iteratively
-    calling `simpson` with successively larger integration intervals, but
+    calling `simpson` with successively higher upper limits of integration, but
     not identical.
 
     >>> def cumulative_simpson_reference(y, x):
@@ -1073,7 +1073,7 @@ def cumulative_simpson(y, *, x=None, dx=1.0, axis=-1, initial=None):
     # validate `axis` and standardize to work along the last axis
     original_shape = y.shape
     try:
-        y = np.moveaxis(y, axis, -1)
+        y = np.swapaxes(y, axis, -1)
     except np.exceptions.AxisError as e:
         message = f"`axis={axis}` is not valid for `y` with `y.ndim={y.ndim}`."
         raise ValueError(message) from e
@@ -1092,7 +1092,7 @@ def cumulative_simpson(y, *, x=None, dx=1.0, axis=-1, initial=None):
                 or (x.ndim == 1 and len(x) == original_shape[axis])):
             raise ValueError(message)
 
-        x = np.broadcast_to(x, y.shape) if x.ndim == 1 else np.moveaxis(x, axis, -1)
+        x = np.broadcast_to(x, y.shape) if x.ndim == 1 else np.swapaxes(x, axis, -1)
         res = _cumulative_simpson_unequal_intervals(y, x)
 
     else:
@@ -1104,7 +1104,7 @@ def cumulative_simpson(y, *, x=None, dx=1.0, axis=-1, initial=None):
         if not (dx.ndim == 0 or dx.shape == alt_input_dx_shape):
             raise ValueError(message)
         dx = np.broadcast_to(dx, final_dx_shape)
-        dx = np.moveaxis(dx, axis, -1)
+        dx = np.swapaxes(dx, axis, -1)
         res = _cumulative_simpson_equal_intervals(y, dx)
 
     if initial is not None:
@@ -1115,12 +1115,12 @@ def cumulative_simpson(y, *, x=None, dx=1.0, axis=-1, initial=None):
         if not (initial.ndim == 0 or initial.shape == alt_initial_input_shape):
             raise ValueError(message)
         initial = np.broadcast_to(initial, alt_initial_input_shape)
-        initial = np.moveaxis(initial, axis, -1)
+        initial = np.swapaxes(initial, axis, -1)
 
         res += initial
         res = np.concatenate((initial, res), axis=-1)
 
-    res = np.moveaxis(res, -1, axis)
+    res = np.swapaxes(res, -1, axis)
     return res
 
 

--- a/scipy/integrate/_quadrature.py
+++ b/scipy/integrate/_quadrature.py
@@ -952,7 +952,7 @@ def cumulative_simpson(y, *, x=None, dx=1.0, axis=-1, initial=None):
         `y`.
     dx : scalar or array_like, optional
         Spacing between elements of `y`. Only used if `x` is None. Can either 
-        be a float, or an array with the same shape as `y`, but size 1 along
+        be a float, or an array with the same shape as `y`, but length 1 along
         `axis`.
     axis : int, optional
         Specifies the axis to integrate along. Default is -1 (last axis).
@@ -961,7 +961,7 @@ def cumulative_simpson(y, *, x=None, dx=1.0, axis=-1, initial=None):
         and add it to the rest of the result. Default is None, which means no
         value at ``x[0]`` is returned and `res` has one element less than `y`
         along the axis of integration. Can either be a float, or an array with
-        the same shape as `y`, but size 1 along `axis`.
+        the same shape as `y`, but length 1 along `axis`.
 
     Returns
     -------
@@ -1044,6 +1044,28 @@ def cumulative_simpson(y, *, x=None, dx=1.0, axis=-1, initial=None):
     >>> ax.plot(x, y_int, 'ro', x, x**3/3 - (x[0])**3/3, 'b-')
     >>> ax.grid()
     >>> plt.show()
+
+    The output of `cumulative_simpson` is similar to that of iteratively
+    calling `simpson` with successively larger integration intervals, but
+    not identical.
+
+    >>> def cumulative_simpson_reference(y, x):
+    ...     return np.asarray([integrate.simpson(y[:i], x=x[:i])
+    ...                        for i in range(2, len(y) + 1)])
+    >>>
+    >>> rng = np.random.default_rng(354673834679465)
+    >>> x, y = rng.random(size=(2, 10))
+    >>> x.sort()
+    >>>
+    >>> res = integrate.cumulative_simpson(y, x=x)
+    >>> ref = cumulative_simpson_reference(y, x)
+    >>> equal = np.abs(res - ref) < 1e-15
+    >>> equal  # not equal when `simpson` has even number of subintervals
+    array([False,  True, False,  True, False,  True, False,  True,  True])
+
+    This is expected: because `cumulative_simpson` has access to more
+    information than `simpson`, it can typically produce more accurate
+    estimates of the underlying integral over subintervals.
 
     """
     y = _ensure_float_array(y)

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -851,7 +851,7 @@ class TestCumulativeSimpson:
 
         ref = cumulative_simpson(y, x=x)
         res = simpson_reference(y, x)
-        np.testing.assert_allclose(res[..., 1::2], ref[..., 1::2], 1e-15)
+        np.testing.assert_allclose(res[..., 1::2], ref[..., 1::2])
         np.testing.assert_allclose(res[..., -1], ref[..., -1])
 
 

--- a/scipy/integrate/tests/test_quadrature.py
+++ b/scipy/integrate/tests/test_quadrature.py
@@ -737,7 +737,7 @@ class TestCumulativeSimpson:
                 None,
                 8 / 3,
                 4,
-                "`axis` must exist in the shape of `y`"
+                "is not valid for `y` with `y.ndim="
             ),
             (
                 # Invalid x
@@ -782,7 +782,7 @@ class TestCumulativeSimpson:
                 None,
                 np.array([1 / 3, 0, 8 / 3]),
                 -1,
-                "`initial` must either be numeric or have the same"
+                "If provided, `initial` must either be a scalar or have the same"
             ),
             (
                 # Invalid input for dx
@@ -791,7 +791,7 @@ class TestCumulativeSimpson:
                 [[1], [2], [1], [1]],
                 None,
                 -1,
-                "`dx` must either be numeric or"
+                "If provided, `dx` must either be a scalar or"
             ),
         ],
     )
@@ -851,7 +851,7 @@ class TestCumulativeSimpson:
 
         ref = cumulative_simpson(y, x=x)
         res = simpson_reference(y, x)
-        np.testing.assert_allclose(res[..., 1::2], ref[..., 1::2])
+        np.testing.assert_allclose(res[..., 1::2], ref[..., 1::2], 1e-15)
         np.testing.assert_allclose(res[..., -1], ref[..., -1])
 
 


### PR DESCRIPTION
#### Reference issue
scipy/scipy#18151

#### What does this implement/fix?
This is a suggested simplification of the input validation and (nonstandard) broadcasting behavior of `cumulative_simpson`. Please check me carefully and merge if you agree that this is a worthwhile simplification.

I've also added an example to the documentation that should prevent bug reports about discrepancies between `simpson` and `cumulative_simpson`.
